### PR TITLE
Refactor/live match response

### DIFF
--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/StrategyApiTemplate.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/StrategyApiTemplate.java
@@ -32,7 +32,7 @@ public abstract class StrategyApiTemplate<T, E> {
         this.endpoint = endpoint;
     }
 
-    // api 조회 후 DB 저장
+    // api 조회 후 엔티티 변환
     public E execute(Object... params){
         // api 호출
         String responseStr = apiCaller.callApi(endpoint, params);
@@ -43,12 +43,5 @@ public abstract class StrategyApiTemplate<T, E> {
 
     }
 
-    // api 조회 후 화면에 응답
-    public T executeWithoutSave(String params){
-        // api호출
-        String responseStr = apiCaller.callApi(endpoint, params);
-        // response to DTO
-        return parser.parse(responseStr);
-    }
 
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/category/categories/CategoryDTO.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/category/categories/CategoryDTO.java
@@ -16,12 +16,4 @@ public class CategoryDTO {
     private String name;
     @JsonProperty("slug")
     private String slug;
-
-    public boolean isAtp(){
-        return "atp".equals(slug);
-    }
-
-    public boolean isWta(){
-        return "wta".equals(slug);
-    }
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/leagueEventsByRound/LeagueEventsByRoundAssemble.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/leagueEventsByRound/LeagueEventsByRoundAssemble.java
@@ -4,7 +4,11 @@ import com.tennisfolio.Tennisfolio.exception.NotFoundException;
 import com.tennisfolio.Tennisfolio.infrastructure.api.base.EntityAssemble;
 import com.tennisfolio.Tennisfolio.common.ExceptionCode;
 import com.tennisfolio.Tennisfolio.exception.InvalidRequestException;
+import com.tennisfolio.Tennisfolio.infrastructure.api.match.liveEvents.ScoreDTO;
+import com.tennisfolio.Tennisfolio.infrastructure.api.match.liveEvents.TimeDTO;
 import com.tennisfolio.Tennisfolio.match.domain.Match;
+import com.tennisfolio.Tennisfolio.match.domain.Period;
+import com.tennisfolio.Tennisfolio.match.domain.Score;
 import com.tennisfolio.Tennisfolio.match.repository.MatchEntity;
 import com.tennisfolio.Tennisfolio.player.application.PlayerService;
 import com.tennisfolio.Tennisfolio.player.domain.Player;
@@ -55,7 +59,58 @@ public class LeagueEventsByRoundAssemble implements EntityAssemble<List<LeagueEv
             Player homePlayer = playerService.getOrCreatePlayerByRapidId(events.getHomeTeam().getRapidPlayerId());
             Player awayPlayer = playerService.getOrCreatePlayerByRapidId(events.getAwayTeam().getRapidPlayerId());
 
-            return new Match(events, round, homePlayer, awayPlayer);
+            ScoreDTO homeScoreDTO = events.getHomeScore();
+            Score homeScore = Score.builder()
+                    .set1(homeScoreDTO.getPeriod1())
+                    .set2(homeScoreDTO.getPeriod2())
+                    .set3(homeScoreDTO.getPeriod3())
+                    .set4(homeScoreDTO.getPeriod4())
+                    .set5(homeScoreDTO.getPeriod5())
+                    .set1Tie(homeScoreDTO.getPeriod1TieBreak())
+                    .set2Tie(homeScoreDTO.getPeriod2TieBreak())
+                    .set3Tie(homeScoreDTO.getPeriod3TieBreak())
+                    .set4Tie(homeScoreDTO.getPeriod4TieBreak())
+                    .set5Tie(homeScoreDTO.getPeriod5TieBreak())
+                    .build();
+
+            ScoreDTO awayScoreDTO = events.getAwayScore();
+            Score awayScore = Score.builder()
+                    .set1(awayScoreDTO.getPeriod1())
+                    .set2(awayScoreDTO.getPeriod2())
+                    .set3(awayScoreDTO.getPeriod3())
+                    .set4(awayScoreDTO.getPeriod4())
+                    .set5(awayScoreDTO.getPeriod5())
+                    .set1Tie(awayScoreDTO.getPeriod1TieBreak())
+                    .set2Tie(awayScoreDTO.getPeriod2TieBreak())
+                    .set3Tie(awayScoreDTO.getPeriod3TieBreak())
+                    .set4Tie(awayScoreDTO.getPeriod4TieBreak())
+                    .set5Tie(awayScoreDTO.getPeriod5TieBreak())
+                    .build();
+            TimeDTO timeSet = events.getTime();
+            Period periodSet = Period.builder()
+                    .set1(timeSet.getPeriod1())
+                    .set2(timeSet.getPeriod2())
+                    .set3(timeSet.getPeriod3())
+                    .set4(timeSet.getPeriod4())
+                    .set5(timeSet.getPeriod5())
+                    .build();
+
+            return Match.builder()
+                    .rapidMatchId(events.getRapidMatchId())
+                    .homeSeed(events.getHomeTeamSeed())
+                    .awaySeed(events.getAwayTeamSeed())
+                    .homeScore(events.getHomeScore().getCurrent())
+                    .awayScore(events.getAwayScore().getCurrent())
+                    .round(round)
+                    .homePlayer(homePlayer)
+                    .awayPlayer(awayPlayer)
+                    .homeSet(homeScore)
+                    .awaySet(awayScore)
+                    .periodSet(periodSet)
+                    .startTimeStamp(events.getStartTimestamp())
+                    .winner(events.getWinner())
+                    .build();
+
         }).collect(Collectors.toList());
 
 

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsAssemble.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsAssemble.java
@@ -6,10 +6,12 @@ import com.tennisfolio.Tennisfolio.match.domain.Match;
 import com.tennisfolio.Tennisfolio.match.dto.LiveMatchResponse;
 import com.tennisfolio.Tennisfolio.player.application.PlayerService;
 import com.tennisfolio.Tennisfolio.player.domain.Player;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Component
 public class LiveEventsAssemble implements EntityAssemble<List<LiveEventsApiDTO>, List<LiveMatchResponse>> {
     private final PlayerService playerService;
 

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsAssemble.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsAssemble.java
@@ -1,0 +1,36 @@
+package com.tennisfolio.Tennisfolio.infrastructure.api.match.liveEvents;
+
+import com.tennisfolio.Tennisfolio.infrastructure.api.base.EntityAssemble;
+import com.tennisfolio.Tennisfolio.infrastructure.api.match.leagueEventsByRound.LeagueEventsByRoundDTO;
+import com.tennisfolio.Tennisfolio.match.domain.Match;
+import com.tennisfolio.Tennisfolio.match.dto.LiveMatchResponse;
+import com.tennisfolio.Tennisfolio.player.application.PlayerService;
+import com.tennisfolio.Tennisfolio.player.domain.Player;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LiveEventsAssemble implements EntityAssemble<List<LiveEventsApiDTO>, List<LiveMatchResponse>> {
+    private final PlayerService playerService;
+
+    public LiveEventsAssemble(PlayerService playerService) {
+        this.playerService = playerService;
+    }
+
+    @Override
+    public List<LiveMatchResponse> assemble(List<LiveEventsApiDTO> dto, Object... params) {
+        if(dto == null || dto.isEmpty()){
+            return List.of();
+        }
+        return dto.stream()
+                .map(this::getLiveMatchResponse)
+                .collect(Collectors.toList());
+
+    }
+
+    private LiveMatchResponse getLiveMatchResponse(LiveEventsApiDTO dto){
+        Player homePlayer = playerService.getOrCreatePlayerByRapidId(dto.getHomeTeam().getRapidPlayerId());
+        Player awayPlayer = playerService.getOrCreatePlayerByRapidId(dto.getAwayTeam().getRapidPlayerId());
+        return new LiveMatchResponse(dto, homePlayer, awayPlayer);
+    }
+}

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsEntityMapper.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsEntityMapper.java
@@ -1,0 +1,21 @@
+package com.tennisfolio.Tennisfolio.infrastructure.api.match.liveEvents;
+
+import com.tennisfolio.Tennisfolio.infrastructure.api.base.EntityAssemble;
+import com.tennisfolio.Tennisfolio.infrastructure.api.base.EntityMapper;
+import com.tennisfolio.Tennisfolio.match.domain.Match;
+import com.tennisfolio.Tennisfolio.match.dto.LiveMatchResponse;
+
+import java.util.List;
+
+public class LiveEventsEntityMapper implements EntityMapper<List<LiveEventsApiDTO>, List<LiveMatchResponse>> {
+    private final EntityAssemble<List<LiveEventsApiDTO>, List<LiveMatchResponse>> entityAssemble;
+
+    public LiveEventsEntityMapper(EntityAssemble<List<LiveEventsApiDTO>, List<LiveMatchResponse>> entityAssemble) {
+        this.entityAssemble = entityAssemble;
+    }
+
+    @Override
+    public List<LiveMatchResponse> map(List<LiveEventsApiDTO> dto, Object... params) {
+        return entityAssemble.assemble(dto, params);
+    }
+}

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsEntityMapper.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsEntityMapper.java
@@ -4,9 +4,11 @@ import com.tennisfolio.Tennisfolio.infrastructure.api.base.EntityAssemble;
 import com.tennisfolio.Tennisfolio.infrastructure.api.base.EntityMapper;
 import com.tennisfolio.Tennisfolio.match.domain.Match;
 import com.tennisfolio.Tennisfolio.match.dto.LiveMatchResponse;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Component
 public class LiveEventsEntityMapper implements EntityMapper<List<LiveEventsApiDTO>, List<LiveMatchResponse>> {
     private final EntityAssemble<List<LiveEventsApiDTO>, List<LiveMatchResponse>> entityAssemble;
 

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsTemplate.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsTemplate.java
@@ -1,22 +1,24 @@
 package com.tennisfolio.Tennisfolio.infrastructure.api.match.liveEvents;
 
 
-import com.tennisfolio.Tennisfolio.infrastructure.api.base.ApiCaller;
-import com.tennisfolio.Tennisfolio.infrastructure.api.base.ResponseParser;
-import com.tennisfolio.Tennisfolio.infrastructure.api.base.RapidApi;
-import com.tennisfolio.Tennisfolio.infrastructure.api.base.StrategyApiTemplate;
+import com.tennisfolio.Tennisfolio.infrastructure.api.base.*;
+import com.tennisfolio.Tennisfolio.match.domain.Match;
+import com.tennisfolio.Tennisfolio.match.dto.LiveMatchResponse;
+import com.tennisfolio.Tennisfolio.player.domain.PlayerAggregate;
+import com.tennisfolio.Tennisfolio.player.dto.TeamDetailsApiDTO;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
-public class LiveEventsTemplate extends StrategyApiTemplate<List<LiveEventsApiDTO>, Void> {
+public class LiveEventsTemplate extends StrategyApiTemplate<List<LiveEventsApiDTO>, List<LiveMatchResponse>> {
 
     public LiveEventsTemplate(
             ApiCaller apiCaller,
-         @Qualifier("liveEventsResponseParser") ResponseParser<List<LiveEventsApiDTO>> parser) {
-        super(apiCaller, parser, null,  RapidApi.LIVEEVENTS);
+         @Qualifier("liveEventsResponseParser") ResponseParser<List<LiveEventsApiDTO>> parser,
+            EntityMapper<List<LiveEventsApiDTO>, List<LiveMatchResponse>> entityMapper) {
+        super(apiCaller, parser, entityMapper,  RapidApi.LIVEEVENTS);
     }
 
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/round/leagueRounds/LeagueRoundsAssemble.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/round/leagueRounds/LeagueRoundsAssemble.java
@@ -33,7 +33,7 @@ public class LeagueRoundsAssemble implements EntityAssemble<List<LeagueRoundsDTO
                 .orElseThrow(() -> new NotFoundException(ExceptionCode.NOT_FOUND));
 
         return dto.stream()
-                .map(round -> new Round(round, season))
+                .map(round -> new Round(round.getRound(), round.getName(), round.getSlug(), season))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/domain/Match.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/domain/Match.java
@@ -1,6 +1,5 @@
 package com.tennisfolio.Tennisfolio.match.domain;
 
-import com.tennisfolio.Tennisfolio.infrastructure.api.match.leagueEventsByRound.LeagueEventsByRoundDTO;
 import com.tennisfolio.Tennisfolio.player.domain.Player;
 import com.tennisfolio.Tennisfolio.round.domain.Round;
 import lombok.AllArgsConstructor;
@@ -40,19 +39,20 @@ public class Match {
 
     private String winner;
 
-    public Match(LeagueEventsByRoundDTO dto, Round round, Player homePlayer, Player awayPlayer){
+    public Match(String rapidMatchId, String homeSeed, String awaySeed, Long homeScore, Long awayScore
+            , Round round, Player homePlayer, Player awayPlayer, Score homeSet, Score awaySet, Period periodSet, String startTimeStamp, String winner){
         this.round = round;
-        this.rapidMatchId = dto.getRapidMatchId();
-        this.homeScore = dto.getHomeScore().getCurrent();
-        this.awayScore = dto.getAwayScore().getCurrent();
-        this.homeSeed = dto.getHomeTeamSeed();
-        this.awaySeed = dto.getAwayTeamSeed();
+        this.rapidMatchId = rapidMatchId;
+        this.homeScore = homeScore;
+        this.awayScore = awayScore;
+        this.homeSeed = homeSeed;
+        this.awaySeed = awaySeed;
         this.homePlayer = homePlayer;
         this.awayPlayer = awayPlayer;
-        this.homeSet = new Score(dto.getHomeScore());
-        this.awaySet = new Score(dto.getAwayScore());
-        this.periodSet = new Period(dto.getTime());
-        this.startTimeStamp = dto.getStartTimestamp();
-        this.winner = dto.getWinner();
+        this.homeSet = homeSet;
+        this.awaySet = awaySet;
+        this.periodSet = periodSet;
+        this.startTimeStamp = startTimeStamp;
+        this.winner = winner;
     }
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/domain/Period.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/domain/Period.java
@@ -2,10 +2,12 @@ package com.tennisfolio.Tennisfolio.match.domain;
 
 import com.tennisfolio.Tennisfolio.infrastructure.api.match.liveEvents.TimeDTO;
 import jakarta.persistence.Embeddable;
+import lombok.Builder;
 import lombok.Getter;
 
 @Embeddable
 @Getter
+@Builder
 public class Period {
     private String set1;
     private String set2;
@@ -14,12 +16,12 @@ public class Period {
     private String set5;
 
     protected Period() {}
-    public Period(TimeDTO dto){
-        this.set1 = dto.getPeriod1();
-        this.set2 = dto.getPeriod2();
-        this.set3 = dto.getPeriod3();
-        this.set4 = dto.getPeriod4();
-        this.set5 = dto.getPeriod5();
+    public Period(String set1, String set2, String set3, String set4, String set5){
+        this.set1 = set1;
+        this.set2 = set2;
+        this.set3 = set3;
+        this.set4 = set4;
+        this.set5 = set5;
 
     }
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/domain/Score.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/domain/Score.java
@@ -2,10 +2,12 @@ package com.tennisfolio.Tennisfolio.match.domain;
 
 import com.tennisfolio.Tennisfolio.infrastructure.api.match.liveEvents.ScoreDTO;
 import jakarta.persistence.Embeddable;
+import lombok.Builder;
 import lombok.Getter;
 
 @Embeddable
 @Getter
+@Builder
 public class Score {
     private Long set1;
     private Long set2;
@@ -19,17 +21,17 @@ public class Score {
     private Long set5Tie;
 
     protected Score() {}
-    public Score(ScoreDTO dto){
-        this.set1 = dto.getPeriod1();
-        this.set2 = dto.getPeriod2();
-        this.set3 = dto.getPeriod3();
-        this.set4 = dto.getPeriod4();
-        this.set5 = dto.getPeriod5();
-        this.set1Tie = dto.getPeriod1TieBreak();
-        this.set2Tie = dto.getPeriod2TieBreak();
-        this.set3Tie = dto.getPeriod3TieBreak();
-        this.set4Tie = dto.getPeriod4TieBreak();
-        this.set5Tie = dto.getPeriod5TieBreak();
+    public Score(Long set1, Long set2, Long set3, Long set4, Long set5, Long set1Tie, Long set2Tie, Long set3Tie, Long set4Tie, Long set5Tie){
+        this.set1 = set1;
+        this.set2 = set2;
+        this.set3 = set3;
+        this.set4 = set4;
+        this.set5 = set5;
+        this.set1Tie = set1Tie;
+        this.set2Tie = set2Tie;
+        this.set3Tie = set3Tie;
+        this.set4Tie = set4Tie;
+        this.set5Tie = set5Tie;
 
     }
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchPlayerResponse.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchPlayerResponse.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class LiveMatchPlayerResponse {
-    private Long playerId;
     private String playerRapidId;
     private String playerName;
     private String playerImage;
@@ -17,8 +16,7 @@ public class LiveMatchPlayerResponse {
     private String playerCountryName;
 
     public LiveMatchPlayerResponse(TeamDTO dto, Player player){
-        this.playerId = player.getPlayerId();
-        this.playerRapidId = player.getRapidPlayerId();
+        this.playerRapidId = player.getRapidPlayerId().value();
         this.playerName = dto.getName();
         this.playerImage = player.getImage();
         this.playerRanking = dto.getRanking();

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchPlayerResponse.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchPlayerResponse.java
@@ -16,7 +16,7 @@ public class LiveMatchPlayerResponse {
     private String playerCountryName;
 
     public LiveMatchPlayerResponse(TeamDTO dto, Player player){
-        this.playerRapidId = player.getRapidPlayerId().value();
+        this.playerRapidId = player.getRapidPlayerId();
         this.playerName = dto.getName();
         this.playerImage = player.getImage();
         this.playerRanking = dto.getRanking();

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchResponse.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchResponse.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LiveMatchResponse {
     private String rapidId;
+    private String category;
     private String tournamentName;
     private String seasonName;
     private String roundName;
@@ -23,6 +24,7 @@ public class LiveMatchResponse {
 
     public LiveMatchResponse(LiveEventsApiDTO dto, Player homePlayer, Player awayPlayer){
         this.rapidId = dto.getRapidId();
+        this.category = dto.getTournament().getCategory().getSlug();
         this.tournamentName = dto.getTournament().getName();
         this.seasonName = dto.getSeason().getName();
         this.roundName = dto.getRound() != null ? dto.getRound().getName() : null;
@@ -32,6 +34,14 @@ public class LiveMatchResponse {
         this.homeScore = new LiveMatchScoreResponse(dto.getHomeScore());
         this.awayScore = new LiveMatchScoreResponse(dto.getAwayScore());
         this.time = new LiveMatchTimeResponse(dto);
+    }
+
+    public boolean isAtp(){
+        return "atp".equals(category);
+    }
+
+    public boolean isWta(){
+        return "wta".equals(category);
     }
 
 

--- a/src/main/java/com/tennisfolio/Tennisfolio/round/domain/Round.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/round/domain/Round.java
@@ -22,10 +22,10 @@ public class Round {
 
     private String slug;
 
-    public Round(LeagueRoundsDTO dto, Season season){
+    public Round(Long round, String name, String slug, Season season){
         this.season = season;
-        this.round = dto.getRound();
-        this.name = dto.getName();
-        this.slug = dto.getSlug();
+        this.round = round;
+        this.name = name;
+        this.slug = slug;
     }
 }


### PR DESCRIPTION
## 제목
<!-- PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) feat: 로그인 UI 구현 -->
Refactor/live match response
## 작업내용
<!-- 작업 사항에 대한 설명을 적어주세요 -->
liveMatch 응답하는 부분 수정
- 기존에 템플릿메서드 패턴에서 메서드 분리했던 것 통합해서 사용할 수 있도록 적용
- 도메인에서 DTO를 의존하지 않도록 원시 타입(String, int등)을 매개변수로 넣음.

## 특이사항
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분을 적어주세요 -->
<!-- 논의해야 할 부분이 있다면 적어주세요 -->
- 모든 도메인에서 ID를 뺴려고 했으나 실패함. 생각보다 너무 복잡했음. -> 이건 프론트에도 영향이 있어서 같이 의논하고 해야될 것 같음.
- 이번에 또 하나의 브랜치에 여러 내용이 들어가도록 수정해버림. 수정이 필요한 부분이 보이면 수정하게됨,,
- 다음 브랜치에서는 하나의 내용만 수정할 수 있기를...
