### PR TITLE
Feat/api worker rate limit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'com.google.guava:guava:33.2.1-jre'
 }
 tasks.withType(JavaCompile) {
 	options.compilerArgs << "-parameters"

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/ApiWorker.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/ApiWorker.java
@@ -1,26 +1,30 @@
 package com.tennisfolio.Tennisfolio.infrastructure.api.base;
 
 import com.google.common.util.concurrent.RateLimiter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-
-public class ApiWorker<T,E>{
-    private final Map<RapidApi, StrategyApiTemplate<T, E>> strategyApiTemplateMap;
+@Component
+@Slf4j
+public class ApiWorker{
+    private final Map<RapidApi, StrategyApiTemplate<?, ?>> strategyApiTemplateMap;
     private final RateLimiter rateLimiter;
 
-    public ApiWorker(List<StrategyApiTemplate<T, E>> strategies) {
+    public ApiWorker(List<StrategyApiTemplate<?, ?>> strategies) {
         this.strategyApiTemplateMap = strategies.stream()
                 .collect(Collectors.toMap(StrategyApiTemplate::getEndPoint, s-> s));
         this.rateLimiter = RateLimiter.create(6.0);
     }
 
-    public E process(RapidApi endpoint, Object ... params){
-        rateLimiter.acquire();
+    public <T, E> E process(RapidApi endpoint, Object ... params){
+        double waited = rateLimiter.acquire();
+        log.info("RateLimiter waited " + waited + "s before executing " + endpoint);
 
-        StrategyApiTemplate<T, E> strategy = strategyApiTemplateMap.get(endpoint);
+        StrategyApiTemplate<T, E> strategy = (StrategyApiTemplate<T, E>) strategyApiTemplateMap.get(endpoint);
         if (strategy == null) {
             throw new IllegalArgumentException("Unknown strategy: " + endpoint);
         }

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/ApiWorker.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/ApiWorker.java
@@ -1,0 +1,30 @@
+package com.tennisfolio.Tennisfolio.infrastructure.api.base;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class ApiWorker<T,E>{
+    private final Map<RapidApi, StrategyApiTemplate<T, E>> strategyApiTemplateMap;
+    private final RateLimiter rateLimiter;
+
+    public ApiWorker(List<StrategyApiTemplate<T, E>> strategies) {
+        this.strategyApiTemplateMap = strategies.stream()
+                .collect(Collectors.toMap(StrategyApiTemplate::getEndPoint, s-> s));
+        this.rateLimiter = RateLimiter.create(6.0);
+    }
+
+    public E process(RapidApi endpoint, Object ... params){
+        rateLimiter.acquire();
+
+        StrategyApiTemplate<T, E> strategy = strategyApiTemplateMap.get(endpoint);
+        if (strategy == null) {
+            throw new IllegalArgumentException("Unknown strategy: " + endpoint);
+        }
+
+        return strategy.execute(params);
+    }
+}

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/StrategyApiTemplate.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/base/StrategyApiTemplate.java
@@ -44,5 +44,9 @@ public abstract class StrategyApiTemplate<T, E> {
 
     }
 
+    public RapidApi getEndPoint(){
+        return endpoint;
+    }
+
 
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsAssemble.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/infrastructure/api/match/liveEvents/LiveEventsAssemble.java
@@ -34,8 +34,17 @@ public class LiveEventsAssemble implements EntityAssemble<List<LiveEventsApiDTO>
     }
 
     private LiveMatchResponse getLiveMatchResponse(LiveEventsApiDTO dto){
-        Player homePlayer = playerService.getOrCreatePlayerByRapidId(dto.getHomeTeam().getRapidPlayerId());
-        Player awayPlayer = playerService.getOrCreatePlayerByRapidId(dto.getAwayTeam().getRapidPlayerId());
-        return new LiveMatchResponse(dto, homePlayer, awayPlayer);
+        Player homePlayer = Player.builder()
+                .rapidPlayerId(dto.getHomeTeam().getRapidPlayerId())
+                .playerName(dto.getHomeTeam().getName())
+                .build();
+
+        Player awayPlayer = Player.builder()
+                .rapidPlayerId(dto.getAwayTeam().getRapidPlayerId())
+                .playerName(dto.getAwayTeam().getName())
+                .build();
+//        Player homePlayer = playerService.getOrCreatePlayerByRapidId(dto.getHomeTeam().getRapidPlayerId());
+//        Player awayPlayer = playerService.getOrCreatePlayerByRapidId(dto.getAwayTeam().getRapidPlayerId());
+        return new LiveMatchResponse(dto);
     }
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchPlayerResponse.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchPlayerResponse.java
@@ -15,13 +15,17 @@ public class LiveMatchPlayerResponse {
     private String playerCountryAlpha;
     private String playerCountryName;
 
-    public LiveMatchPlayerResponse(TeamDTO dto, Player player){
-        this.playerRapidId = player.getRapidPlayerId();
+    public LiveMatchPlayerResponse(TeamDTO dto){
+        this.playerRapidId = dto.getRapidPlayerId();
         this.playerName = dto.getName();
-        this.playerImage = player.getImage();
         this.playerRanking = dto.getRanking();
         this.playerCountryAlpha = dto.getCountry().getAlpha();
         this.playerCountryName = dto.getCountry().getName();
+
+    }
+
+    public void setPlayerInfo(String playerImage){
+        this.playerImage = playerImage;
 
     }
 }

--- a/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchResponse.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/match/dto/LiveMatchResponse.java
@@ -14,6 +14,7 @@ public class LiveMatchResponse {
     private String seasonName;
     private String roundName;
     private String status;
+
     private LiveMatchPlayerResponse homePlayer;
     private LiveMatchPlayerResponse awayPlayer;
     private LiveMatchScoreResponse homeScore;
@@ -22,18 +23,23 @@ public class LiveMatchResponse {
 
 
 
-    public LiveMatchResponse(LiveEventsApiDTO dto, Player homePlayer, Player awayPlayer){
+    public LiveMatchResponse(LiveEventsApiDTO dto){
         this.rapidId = dto.getRapidId();
         this.category = dto.getTournament().getCategory().getSlug();
         this.tournamentName = dto.getTournament().getName();
         this.seasonName = dto.getSeason().getName();
         this.roundName = dto.getRound() != null ? dto.getRound().getName() : null;
         this.status = dto.getStatus().getDescription();
-        this.homePlayer = new LiveMatchPlayerResponse(dto.getHomeTeam(), homePlayer);
-        this.awayPlayer = new LiveMatchPlayerResponse(dto.getAwayTeam(), awayPlayer);
+        this.homePlayer = new LiveMatchPlayerResponse(dto.getHomeTeam());
+        this.awayPlayer = new LiveMatchPlayerResponse(dto.getAwayTeam());
         this.homeScore = new LiveMatchScoreResponse(dto.getHomeScore());
         this.awayScore = new LiveMatchScoreResponse(dto.getAwayScore());
         this.time = new LiveMatchTimeResponse(dto);
+    }
+
+    public void setPlayerImage(String homePlayerImage, String awayPlayerImage){
+        this.homePlayer.setPlayerInfo(homePlayerImage);
+        this.awayPlayer.setPlayerInfo(awayPlayerImage);
     }
 
     public boolean isAtp(){

--- a/src/main/java/com/tennisfolio/Tennisfolio/player/infrastructure/PlayerProvider.java
+++ b/src/main/java/com/tennisfolio/Tennisfolio/player/infrastructure/PlayerProvider.java
@@ -1,0 +1,32 @@
+package com.tennisfolio.Tennisfolio.player.infrastructure;
+
+import com.tennisfolio.Tennisfolio.infrastructure.api.base.ApiWorker;
+import com.tennisfolio.Tennisfolio.infrastructure.api.base.RapidApi;
+import com.tennisfolio.Tennisfolio.infrastructure.api.player.teamImage.PlayerImageService;
+import com.tennisfolio.Tennisfolio.player.domain.Player;
+import com.tennisfolio.Tennisfolio.player.domain.PlayerAggregate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlayerProvider {
+    private final PlayerRepository playerRepository;
+    private final PlayerImageService playerImageService;
+    private final ApiWorker apiWorker;
+
+    public PlayerProvider(PlayerRepository playerRepository, PlayerImageService playerImageService, ApiWorker apiWorker) {
+        this.playerRepository = playerRepository;
+        this.playerImageService = playerImageService;
+        this.apiWorker = apiWorker;
+    }
+
+    public Player provide(String rapidId){
+        return playerRepository.findByRapidPlayerId(rapidId)
+                .orElseGet(() -> {
+                    PlayerAggregate agg =apiWorker.process(RapidApi.TEAMDETAILS, rapidId);
+                    Player player = agg.toPlayer();
+                    String path = playerImageService.fetchImage(rapidId);
+                    player.updateProfileImage(path);
+                    return player;
+                });
+    }
+}

--- a/src/test/java/com/tennisfolio/Tennisfolio/tournament/service/TournamentSyncServiceTest.java
+++ b/src/test/java/com/tennisfolio/Tennisfolio/tournament/service/TournamentSyncServiceTest.java
@@ -55,6 +55,10 @@ public class TournamentSyncServiceTest {
     @Mock
     ResponseParser<LeagueDetailsDTO> leagueParser;
 
+
+
+    List<StrategyApiTemplate<?, ?>> strategies = new ArrayList<>();
+
     private StrategyApiTemplate<List<CategoryTournamentsDTO>, List<Tournament>> categoryTemplate;
     private StrategyApiTemplate<TournamentInfoDTO, Tournament> infoTemplate;
     private StrategyApiTemplate<LeagueDetailsDTO, Tournament> leagueTemplate;
@@ -78,7 +82,13 @@ public class TournamentSyncServiceTest {
         infoTemplate = new FakeTournamentInfo(apiCaller, tournamentInfoParser, fakeTournamentInfoMapper, RapidApi.TOURNAMENTINFO);
         leagueTemplate = new FakeLeagueDetails(apiCaller, leagueParser, fakeLeagueDetailsMapper, RapidApi.LEAGUEDETAILS);
 
-        service = new TournamentSyncService(categoryTemplate, infoTemplate, leagueTemplate, categoryService, fakeTournamentRepository);
+        strategies.add(categoryTemplate);
+        strategies.add(infoTemplate);
+        strategies.add(leagueTemplate);
+
+        ApiWorker apiWorker = new ApiWorker(strategies);
+
+        service = new TournamentSyncService(apiWorker, categoryService, fakeTournamentRepository);
     }
 
     @Test


### PR DESCRIPTION
## 제목
<!-- PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) feat: 로그인 UI 구현 -->
Feat/api worker rate limit

## 작업내용
<!-- 작업 사항에 대한 설명을 적어주세요 -->
 - rapidApi를 1초에 6번만 호출하도록 제한
 - wta, atp 30초 배치에서 player duplicate 오류 수정
## 특이사항
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분을 적어주세요 -->
<!-- 논의해야 할 부분이 있다면 적어주세요 -->
 - 로컬에서의 테스트는 한계가 있어 배포해서 더 테스트가 필요